### PR TITLE
Disable check-sat, update reason for check-repoclosure disabling

### DIFF
--- a/rpmdeplint.fmf
+++ b/rpmdeplint.fmf
@@ -6,11 +6,16 @@ discover:
     how: shell
     tests:
     # for x86_64
-    - name: check-sat-x86_64
-      test: /rpmdeplint_runner/run.py run-test --name check-sat --task-id $TASK_ID --release $RELEASE_ID --arch x86_64
-      result: custom
-      duration: 20m
-# Feel free to uncomment, but beware it takes around an hour because it checks every package in repo
+# rmdepcheck does this faster:
+# https://github.com/fedora-ci/rmdepcheck-pipeline
+# https://forge.fedoraproject.org/quality/rmdepcheck
+#    - name: check-sat-x86_64
+#      test: /rpmdeplint_runner/run.py run-test --name check-sat --task-id $TASK_ID --release $RELEASE_ID --arch x86_64
+#      result: custom
+#      duration: 20m
+# rmdepcheck does this faster and more accurately:
+# https://github.com/fedora-ci/rmdepcheck-pipeline
+# https://forge.fedoraproject.org/quality/rmdepcheck
 #    - name: check-repoclosure-x86_64
 #      test: /rpmdeplint_runner/run.py run-test --name check-repoclosure --task-id $TASK_ID --release $RELEASE_ID --arch x86_64
 #      result: custom


### PR DESCRIPTION
The ultimate result of our attempt to figure out why check-repoclosure is so slow and fix it was that I wrote rmdepcheck to replace it instead:
https://pagure.io/fedora-ci/general/issue/489#comment-993161

We've now had rmdepcheck running in openQA for over half a year, and in Fedora CI for several months. AFAIK it is performing well, it runs fast and its results seem accurate, more accurate than rpmdeplint repoclosure was.

We believe it fully replaces check-sat and check-repoclosure from rpmdeplint. The main mode replaces check-repoclosure and the bonus "installability" check replaces check-sat. So it should be OK to disable check-sat here, and also update the comment explaining why check-repoclosure is disabled to say that rmdepcheck replaces it.