### PR TITLE
Adjust durations: 30m for prepare, 20m for all tests (#62)

### DIFF
--- a/rpmdeplint.fmf
+++ b/rpmdeplint.fmf
@@ -31,6 +31,7 @@
 /steps:
   /prepare:
     summary: Prepare the environment for rpmdeplint
+    duration: 30m
     order: 50
     test: |
       if [[ -n "$BODHI_UPDATE_ID" ]]; then
@@ -59,5 +60,4 @@
       test+: " --check upgrade"
     /conflicts:
       test+: " --check conflicts"
-      duration: 360m
     # repoclosure is not run because rmdepcheck does it more efficently


### PR DESCRIPTION
As we want to try running this pipeline on large updates again now it's faster, we need to give the prepare step a longer duration so it has enough time to download very large updates. 30m is what we settled on for rmdepcheck after some testing, so we'll try the same here.

Also drop the 360m duration for the conflict check test; it should no longer be needed, that test is much faster now.